### PR TITLE
Changing step functions to only use the first 5 ECS Task ARNs

### DIFF
--- a/PetAdoptions/cdk/pet_stack/lib/fis_serverless/fis.ecs.asl.json
+++ b/PetAdoptions/cdk/pet_stack/lib/fis_serverless/fis.ecs.asl.json
@@ -32,7 +32,7 @@
           "Targets": {
             "ecsworkshoptask": {
               "ResourceType": "aws:ecs:task",
-              "ResourceArns.$": "$.TaskArns",
+              "ResourceArns.$": "States.ArrayGetItem(States.ArrayPartition($.TaskArns,5),0)",
               "SelectionMode": "ALL"
             }
           },


### PR DESCRIPTION
*Description of changes:*
Limiting the number of ECS Task ARNs used when creating the experiment template to no more than 5 to avoid a possible error.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
