### PR TITLE
template name Tag fix

### DIFF
--- a/access-control-experiment/create-fis-ecs-access-control-experiment-template.sh
+++ b/access-control-experiment/create-fis-ecs-access-control-experiment-template.sh
@@ -9,7 +9,7 @@ aws fis create-experiment-template \
                 "Instances-Target-1": {
                         "resourceType": "aws:ec2:instance",
                         "resourceTags": {
-                                "Name": "Services/PetSearchEc2/PetSearchEc2"
+                                "Name": "Services/ecsEc2PetSearchLaunchTemplate"
                         },
                         "selectionMode": "PERCENT(50)"
                 }


### PR DESCRIPTION
Fix in the create-fis-ecs-access-control-experiment-template.sh of the tag value to "Services/ecsEc2PetSearchLaunchTemplate"