### PR TITLE
updated kube version to 1.29

### DIFF
--- a/PetAdoptions/cdk/pet_stack/lib/common/container-image-builder.ts
+++ b/PetAdoptions/cdk/pet_stack/lib/common/container-image-builder.ts
@@ -32,7 +32,7 @@ export class ContainerImageBuilder extends Construct {
             repositoryName: props.repositoryName,
             imageScanOnPush: true,
             removalPolicy: cdk.RemovalPolicy.DESTROY,
-            autoDeleteImages: true,
+            emptyOnDelete: true,
         });
         const image = new ecrassets.DockerImageAsset(this, props.repositoryName + 'DockerImageAsset', {
           directory: props.dockerImageAssetDirectory

--- a/PetAdoptions/cdk/pet_stack/lib/services.ts
+++ b/PetAdoptions/cdk/pet_stack/lib/services.ts
@@ -415,13 +415,13 @@ export class Services extends Stack {
             defaultCapacity: 0,
             // defaultCapacityInstance: ec2.InstanceType.of(ec2.InstanceClass.M5, ec2.InstanceSize.XLARGE),
             secretsEncryptionKey: secretsKey,
-            version: KubernetesVersion.of('1.27'),
+            version: KubernetesVersion.of('1.29'),
             kubectlLayer: new KubectlLayer(this, 'kubectl')
         });
 
         const eksOptimizedImage = new eks.EksOptimizedImage(/* all optional props */ {
             cpuArch: eks.CpuArch.X86_64,
-            kubernetesVersion: '1.27',
+            kubernetesVersion: '1.29',
             nodeType: eks.NodeType.STANDARD,
         });
 


### PR DESCRIPTION
*Issue #, if available:*
Current Kube version is 1.27
*Description of changes:*
New Kube version is 1.29

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
