### PR TITLE
Fix serverless stack cw policy limit

### DIFF
--- a/PetAdoptions/cdk/pet_stack/lib/fis_serverless.ts
+++ b/PetAdoptions/cdk/pet_stack/lib/fis_serverless.ts
@@ -116,7 +116,10 @@ export class FisServerless extends Stack {
                 "iam:PassRole"]
         }));
 
-        const logGroup = new LogGroup(this, 'StateMachineECSFISLogs');
+        const logGroup = new LogGroup(this, `StateMachineECSFISLogs`, {
+                  logGroupName: `/aws/vendedlogs/StateMachineECSFIS`
+        });
+
 
         const stateMachine = new stepfunctions.StateMachine(this, 'StateMachineECSFIS', {
             definitionBody: stepfunctions.DefinitionBody.fromString(machineDefinition.replace("${FISRole}", fisRole.roleArn)),

--- a/PetAdoptions/cdk/pet_stack/lib/fis_serverless.ts
+++ b/PetAdoptions/cdk/pet_stack/lib/fis_serverless.ts
@@ -6,6 +6,7 @@ import * as stepfunctions from 'aws-cdk-lib/aws-stepfunctions';
 import { Construct } from 'constructs';
 import { readFileSync } from 'fs';
 import { LogGroup } from 'aws-cdk-lib/aws-logs';
+import { RemovalPolicy } from 'aws-cdk-lib';
 
 export class FisServerless extends Stack {
     constructor(scope: Construct, id: string, props?: StackProps) {
@@ -116,8 +117,9 @@ export class FisServerless extends Stack {
                 "iam:PassRole"]
         }));
 
-        const logGroup = new LogGroup(this, `StateMachineECSFISLogs`, {
-                  logGroupName: `/aws/vendedlogs/StateMachineECSFIS`
+        const logGroup = new LogGroup(this, 'StateMachineECSFISLogs', {
+                  logGroupName: '/aws/vendedlogs/StateMachineECSFIS',
+                  removalPolicy: RemovalPolicy.DESTROY
         });
 
 


### PR DESCRIPTION
*Issue #, if available:*
FisServerless stack fails because of log policy limit
*Description of changes:*
vended logs needs to be added to the path as well as the removal of the logs when the stack gets destroyed

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
