### PR TITLE
Fix Cloud9Stack deployment when using Workshop Studio

### DIFF
--- a/cloud9-cfn.yaml
+++ b/cloud9-cfn.yaml
@@ -118,7 +118,6 @@ Metadata:
           - C9InstanceVolumeSize
           - C9Image
           - PatchC9Instance
-          - Cloud9OwnerRole
 
 Resources:
   VPC:

--- a/supporting-services/cloud9/modules/cloud9.ts
+++ b/supporting-services/cloud9/modules/cloud9.ts
@@ -29,11 +29,6 @@ export class Cloud9Environment extends Construct {
             template.getParameter("EnvironmentName").default = props.name;
         }
 
-        if (props.cloud9OwnerArn) {
-            template.getParameter("Cloud9OwnerRole").default = props.cloud9OwnerArn.valueOf();
-        }
-
-        this.c9Role = template.getResource("C9Role") as CfnRole;
-
+        this.c9Role = template.getResource("FisWorkshopC9Role") as CfnRole;
     }
 }


### PR DESCRIPTION
Cloud9Stack deployment breaks due to referencing unused parameter 'Cloud9OwnerRole' and referencing renamed resource 'C9Role' -> 'FisWorkshopC9Role'.

*Issue #, if available:*

*Description of changes:*
Remove unused parameter 'Cloud9OwnerRole' and update imported 'FisWorkshopC9Role' resource name

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
