### PR TITLE
WorkshopOwnerArn default value fix

### DIFF
--- a/cloud9-cfn.yaml
+++ b/cloud9-cfn.yaml
@@ -33,7 +33,7 @@ Parameters:
   WorkshopOwnerArn:
     Type: String
     Description: The Arn of the Cloud9 Owner to be set if 3rdParty deployment.
-    Default: ""
+    Default: "AWS::NoValue"
   FisWorkshopC9InstanceVolumeSize: 
     Type: Number
     Description: The Size in GB of the Cloud9 Instance Volume. 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix of the default value for the WorkshopOwnerArn parameter to ensure that SkipOwnerArn coditions properly met. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
