### PR TITLE
removed user var from pip install for AWS CLi

### DIFF
--- a/cloud9-cfn.yaml
+++ b/cloud9-cfn.yaml
@@ -627,7 +627,7 @@ Resources:
             runCommand:
             - apt update -y
             - apt install -y jq gettext bash-completion moreutils
-            - pip install --user --upgrade awscli
+            - pip install --upgrade awscli
             - sudo -i -u ubuntu bash -l -c "nvm install node --default"
             - sudo -i -u ubuntu bash -l -c "nvm alias default node"
             - sudo -i -u ubuntu bash -l -c "nvm exec node npm install -g aws-cdk --force"


### PR DESCRIPTION
*Issue #, if available:*

AWS cli not updating in Cloud9

*Description of changes:*

AWS Cli should update after initial boot of cloud9

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
