### PR TITLE
Fix for the ARM-based macbooks

### DIFF
--- a/PetAdoptions/petsearch-java/Dockerfile
+++ b/PetAdoptions/petsearch-java/Dockerfile
@@ -6,7 +6,7 @@ COPY ./src ./src
 COPY ./settings.gradle ./settings.gradle
 
 ENV GRADLE_OPTS "-Dorg.gradle.daemon=false"
-RUN gradle build -DexcludeTags='integration' 
+RUN gradle build -DexcludeTags='integration'
 
 FROM --platform=linux/amd64 amazoncorretto:17-alpine
 WORKDIR /app

--- a/PetAdoptions/petsearch-java/Dockerfile
+++ b/PetAdoptions/petsearch-java/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 gradle:7.3-jdk17 as build
+FROM --platform=linux/amd64 gradle:8.10-jdk17 as build
 
 WORKDIR /app
 COPY ./build.gradle ./build.gradle
@@ -6,7 +6,7 @@ COPY ./src ./src
 COPY ./settings.gradle ./settings.gradle
 
 ENV GRADLE_OPTS "-Dorg.gradle.daemon=false"
-RUN gradle build -DexcludeTags='integration'
+RUN gradle build -DexcludeTags='integration' 
 
 FROM --platform=linux/amd64 amazoncorretto:17-alpine
 WORKDIR /app

--- a/PetAdoptions/petsite/petsite/Dockerfile
+++ b/PetAdoptions/petsite/petsite/Dockerfile
@@ -6,6 +6,16 @@ EXPOSE 443
 FROM --platform=linux/amd64 mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim-amd64 AS build
 WORKDIR /src
 COPY . .
+
+# If using arm-based mac (m1, m2, m3...) you need to enable rosetta on your container settings to successfully compile this code
+# As of macOS Ventura, Rosetta 2 has gained the ability to translate x86-64 code within Linux virtual machines running on Apple Silicon Macs.
+# Make sure your finch settings (~/.finch/finch.yaml) have this entry (and make sure to restart the finch vm if you make changes):
+#     rosetta: true
+# This is needed for .net 6, 7 & 8 (should be fixed on .net9 see https://github.com/dotnet/runtime/pull/102509) 
+#
+# Also for .net 7 & 8 you also need to uncomment this line to get `dotnet restore` to complete
+ENV DOTNET_EnableWriteXorExecute=0
+
 RUN dotnet restore "PetSite.csproj" 
 RUN dotnet build "PetSite.csproj" -c Release -o /app/build  -a x64
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Building this repo fails on the local **ARM-based MacBooks**. This PR fixes it and allows build to successfully complete on the MacBooks (m1 and later).

Additional info:
You also need to enable Rosetta on your container settings to successfully compile dotnet code.
As of macOS Ventura, Rosetta 2 has gained the ability to translate x86-64 code within Linux virtual machines running on Apple Silicon Macs. Therefore, make sure your finch settings (~/.finch/finch.yaml) have this entry:
```rosetta: true```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
