### PR TITLE
update replicas 2

### DIFF
--- a/PetAdoptions/petadoptionshistory-py/deployment.yaml
+++ b/PetAdoptions/petadoptionshistory-py/deployment.yaml
@@ -31,7 +31,7 @@ spec:
   selector:
     matchLabels:
       app: pethistory
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:


### PR DESCRIPTION
*Issue #, if available:*

Pethistory replica was 1. So if the node died, Pethistory was down.

*Description of changes:*

Pethistory replica default is now 2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
