### PR TITLE
fixed deprecated config logging exporter with debug exporter

### DIFF
--- a/PetAdoptions/petadoptionshistory-py/otel-collector-config.yaml
+++ b/PetAdoptions/petadoptionshistory-py/otel-collector-config.yaml
@@ -47,8 +47,8 @@ data:
         timeout: 60s
 
     exporters:
-      logging:
-        loglevel: debug
+      debug:
+        verbosity: detailed
       awsxray:
       awsemf:
         namespace: "PetAdoptionsHistory"


### PR DESCRIPTION
*Issue #, if available:*

The pethistory container failed due to depreciated logging config.

ubuntu@dev:~/environment/workshopfiles/fis-workshop/eks-experiment$ kubectl get pods
NAME                                    READY   STATUS             RESTARTS        AGE
pethistory-deployment-c6f6dcdc8-n5v9m   1/2     Terminating        151 (12h ago)   12h
pethistory-deployment-c6f6dcdc8-r9ccb   1/2     CrashLoopBackOff   1 (5s ago)      7s
pethistory-deployment-c6f6dcdc8-wp829   1/2     CrashLoopBackOff   2 (20s ago)     38s
petsite-deployment-868479745d-gk2b6     1/1     Running            0               12h
petsite-deployment-868479745d-lmczf     1/1     Running            0               12h
xray-daemon-9tk9f                       1/1     Running            0               13h
xray-daemon-b9sdd                       1/1     Running            0               13h
ubuntu@dev:~/environment/workshopfiles/fis-workshop/eks-experiment$ kubectl logs pethistory-deployment-c6f6dcdc8-r9ccb  -c aws-otel-collector
2025/03/05 12:50:15 ADOT Collector version: v0.42.0
2025/03/05 12:50:15 found no extra config, skip it, err: open /opt/aws/aws-otel-collector/etc/extracfg.txt: no such file or directory
2025/03/05 12:50:15 attn: users of the `datadog`, `logzio`, `sapm`, `signalfx` exporter components. please refer to https://github.com/aws-observability/aws-otel-collector/issues/2734 in regards to an upcoming ADOT Collector breaking change

*Description of changes:*

Added, 

-      logging:
-        loglevel: debug
+      debug:
+        verbosity: detailed



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
