### PR TITLE
fixed role arn as it gave both east and west back

### DIFF
--- a/access-control-experiment/run-access-control-setup.sh
+++ b/access-control-experiment/run-access-control-setup.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-ROLEARN=$(aws iam list-roles | jq '.Roles[].Arn | select(contains("cfn-exec"))' -r)
-
+ROLEARN=$(aws iam list-roles | jq '.Roles[].Arn | select(contains("cfn-exec") and contains("us-east-1"))' -r)
 ROLE_NAME="FisWorkshopServiceRole"
 
 echo "#########################################################"


### PR DESCRIPTION
*Issue #, if available:*

ROLE ARN gave back east and west which broke the script

*Description of changes:*

only give back east region.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
