### PR TITLE
api setup sh scripts fix to us-east-1

### DIFF
--- a/api-actions-experiment/run-api-throttling-setup.sh
+++ b/api-actions-experiment/run-api-throttling-setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ROLEARN=$(aws iam list-roles | jq '.Roles[].Arn | select(contains("cfn-exec"))' -r)
+ROLEARN=$(aws iam list-roles | jq '.Roles[].Arn | select(contains("cfn-exec") and contains("us-east-1"))' -r)
 
 echo "Stack deployment takes about 1min"
 aws cloudformation create-stack --stack-name fisapithrottle --template-body file://api-throttling.yaml --parameters ParameterKey=LambdaFunctionName,ParameterValue=fis-workshop-api-errors-throttling ParameterKey=apiGatewayName,ParameterValue=fis-workshop-throttle ParameterKey=apiGatewayStageName,ParameterValue=v1 --capabilities CAPABILITY_NAMED_IAM --role-arn $ROLEARN

--- a/api-actions-experiment/run-api-unavailable-setup.sh
+++ b/api-actions-experiment/run-api-unavailable-setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ROLEARN=$(aws iam list-roles | jq '.Roles[].Arn | select(contains("cfn-exec"))' -r)
+ROLEARN=$(aws iam list-roles | jq '.Roles[].Arn | select(contains("cfn-exec") and contains("us-east-1"))' -r)
 SUBNETID=$(aws ec2 describe-subnets --filters "Name=tag:Name,Values=Services/Microservices/PublicSubnet1" --query "Subnets[].SubnetId" --output text)
 
 echo "Stack deployment takes about 2min"


### PR DESCRIPTION
*Issue #, if available:*
179
*Description of changes:*
Fixed run-api-unavailable-setup.sh and run-api-unavailable-setup.sh first line of code was resulting in the variable returning two ARNs leading to variable use to fail. Fixed to only select ARN from us-east-1.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
