### PR TITLE
Ecs ssm task sidecar memory fix

### DIFF
--- a/PetAdoptions/cdk/pet_stack/lib/services/ecs-ec2-service.ts
+++ b/PetAdoptions/cdk/pet_stack/lib/services/ecs-ec2-service.ts
@@ -148,7 +148,7 @@ export abstract class EcsEc2Service extends Construct {
 
     this.taskDefinition.addContainer('amazon-ssm-agent',{
       image: ecs.ContainerImage.fromRegistry('public.ecr.aws/amazon-ssm-agent/amazon-ssm-agent:latest'),
-      memoryLimitMiB: 256,
+      memoryLimitMiB: 512,
       essential: false,
       //cpu: 256,
       logging,

--- a/PetAdoptions/cdk/pet_stack/lib/services/ecs-service.ts
+++ b/PetAdoptions/cdk/pet_stack/lib/services/ecs-service.ts
@@ -165,7 +165,7 @@ export abstract class EcsService extends Construct {
 
     this.taskDefinition.addContainer('amazon-ssm-agent',{
       image: ecs.ContainerImage.fromRegistry('public.ecr.aws/amazon-ssm-agent/amazon-ssm-agent:latest'),
-      memoryLimitMiB: 256,
+      memoryLimitMiB: 512,
       essential: false,
       //cpu: 256,
       logging,

--- a/api-actions-experiment/run-api-throttling-setup.sh
+++ b/api-actions-experiment/run-api-throttling-setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ROLEARN=$(aws iam list-roles | jq '.Roles[].Arn | select(contains("cfn-exec"))' -r)
+ROLEARN=$(aws iam list-roles | jq '.Roles[].Arn | select(contains("cfn-exec") and contains("us-east-1"))' -r)
 
 echo "Stack deployment takes about 1min"
 aws cloudformation create-stack --stack-name fisapithrottle --template-body file://api-throttling.yaml --parameters ParameterKey=LambdaFunctionName,ParameterValue=fis-workshop-api-errors-throttling ParameterKey=apiGatewayName,ParameterValue=fis-workshop-throttle ParameterKey=apiGatewayStageName,ParameterValue=v1 --capabilities CAPABILITY_NAMED_IAM --role-arn $ROLEARN

--- a/api-actions-experiment/run-api-unavailable-setup.sh
+++ b/api-actions-experiment/run-api-unavailable-setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ROLEARN=$(aws iam list-roles | jq '.Roles[].Arn | select(contains("cfn-exec"))' -r)
+ROLEARN=$(aws iam list-roles | jq '.Roles[].Arn | select(contains("cfn-exec") and contains("us-east-1"))' -r)
 SUBNETID=$(aws ec2 describe-subnets --filters "Name=tag:Name,Values=Services/Microservices/PublicSubnet1" --query "Subnets[].SubnetId" --output text)
 
 echo "Stack deployment takes about 2min"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
modified ECS task definition for SSM agent sidecar to increase memory from 256 to 512, sidecars currently fail with insufficient memory. Testing with 512 is successful. Modified ecs-ec2-service.ts and ecs-service.ts

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
