### PR TITLE
Fix EKS nodegroup IAM role race condition

### DIFF
--- a/PetAdoptions/cdk/pet_stack/lib/services.ts
+++ b/PetAdoptions/cdk/pet_stack/lib/services.ts
@@ -487,6 +487,9 @@ export class Services extends Stack {
 
         // Adding Node Group
         const eksPetsiteASGClusterNodeGroup = new eks.Nodegroup(this, 'eksPetsiteASGClusterNodeGroup', eksPetSiteNodegroupProps);
+        
+        // Ensure IAM role is fully propagated before nodegroup creation
+        eksPetsiteASGClusterNodeGroup.node.addDependency(eksPetsiteASGClusterNodeGroupRole);
 
         // Tagging  Node Group resources https://classic.yarnpkg.com/en/package/eks-nodegroup-asg-tags-cdk
         new NodegroupAsgTags(this, 'petSiteNodeGroupAsgTags', {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixed EKS nodegroup creation failure due to IAM eventual consistency race condition. Added explicit dependency between the nodegroup and its IAM role (eksPetsiteASGClusterNodeGroupRole) to ensure the role is fully propagated across AWS services before the nodegroup attempts to use it. This resolves the "Amazon EKS Nodegroups was unable to assume the service-linked role" error that occurred when the service-linked role AWSServiceRoleForAmazonEKSNodegroup was created for the first 
time in an account.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
