### PR TITLE
fix: replace unreliable goproxy.io with proxy.golang.org

### DIFF
--- a/PetAdoptions/cdk/pet_stack/lib/azMonitorDockerBuild/Dockerfile
+++ b/PetAdoptions/cdk/pet_stack/lib/azMonitorDockerBuild/Dockerfile
@@ -1,7 +1,7 @@
 # Start from the official Golang image
 FROM --platform=linux/amd64 public.ecr.aws/docker/library/golang:1.23.6-alpine
 
-ENV GOPROXY=https://goproxy.io,direct
+ENV GOPROXY=https://proxy.golang.org,direct
 
 # Add necessary tools
 RUN apk add --no-cache ca-certificates tzdata git

--- a/PetAdoptions/cdk/pet_stack/lib/user_simulation-stack.ts
+++ b/PetAdoptions/cdk/pet_stack/lib/user_simulation-stack.ts
@@ -220,7 +220,7 @@ export class UserSimulationStack extends cdk.Stack {
     const dockerfileContentAzMonitor = `# Start from the official Golang image
 FROM --platform=linux/amd64 public.ecr.aws/docker/library/golang:1.23.6-alpine
 
-ENV GOPROXY=https://goproxy.io,direct
+ENV GOPROXY=https://proxy.golang.org,direct
 
 # Add necessary tools
 RUN apk add --no-cache ca-certificates tzdata git

--- a/PetAdoptions/cdk/pet_stack/resources/event-demos/riv-cop301-2022/ecs-api/Dockerfile
+++ b/PetAdoptions/cdk/pet_stack/resources/event-demos/riv-cop301-2022/ecs-api/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.18 as builder
-ENV GOPROXY=https://goproxy.io,direct
+ENV GOPROXY=https://proxy.golang.org,direct
 WORKDIR /go/src/app
 COPY . .
 RUN go get .

--- a/PetAdoptions/payforadoption-go/Dockerfile
+++ b/PetAdoptions/payforadoption-go/Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 golang:1.23.3-alpine as builder
 WORKDIR /go/src/app
 COPY . .
-ENV GOPROXY=https://goproxy.io,direct
+ENV GOPROXY=https://proxy.golang.org,direct
 RUN go get .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o app .
 

--- a/PetAdoptions/petlistadoptions-go/Dockerfile
+++ b/PetAdoptions/petlistadoptions-go/Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=linux/amd64 golang:1.23.3-alpine as builder
 WORKDIR /go/src/app
 COPY . .
-ENV GOPROXY=https://goproxy.io,direct
+ENV GOPROXY=https://proxy.golang.org,direct
 RUN go get .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o app .
 


### PR DESCRIPTION
goproxy.io returns 502 Bad Gateway errors causing Docker builds to fail during go module downloads. Switch to the official Go module proxy (proxy.golang.org) across all Go Dockerfiles and inline CDK Dockerfile.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
