### PR TITLE
Fix RDS SLR race on fresh accounts + make disposable resources destro…

### DIFF
--- a/.github/workflows/deploy_main.yml
+++ b/.github/workflows/deploy_main.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '23.x'  # adjust version as needed
+          node-version: '24.x'
 
       - name: Cache Node.js dependencies
         id: cache
@@ -223,7 +223,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: '23.x'
+          node-version: '24.x'
 
       - name: Install global dependencies
         run: npm install aws-cdk -g

--- a/.github/workflows/deploy_main.yml
+++ b/.github/workflows/deploy_main.yml
@@ -24,7 +24,7 @@ jobs:
       deployment_status: ${{ job.status }}
     steps: 
       - name: Git clone the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Debug directory structure
         run: |
@@ -32,7 +32,7 @@ jobs:
           ls -R
 
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::992382547812:role/GithubActionRole
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
@@ -73,13 +73,13 @@ jobs:
         shell: bash 
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '23.x'  # adjust version as needed
 
       - name: Cache Node.js dependencies
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ./node_modules
           key: ${{ runner.os }}-node-${{ hashFiles('./package-lock.json') }}
@@ -136,10 +136,10 @@ jobs:
       verification_status: ${{ job.status }}
     steps:
       - name: Git clone the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: configure aws credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ env.EE_TEAM_ROLE_ARN }}
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
@@ -210,10 +210,10 @@ jobs:
       )
     steps:
       - name: Git clone the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ env.EE_TEAM_ROLE_ARN }}
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
@@ -221,7 +221,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '23.x'
 

--- a/.github/workflows/deploy_main.yml
+++ b/.github/workflows/deploy_main.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Deploy Application Stacks
         working-directory: ./PetAdoptions/cdk/pet_stack
         run: |
-          cdk deploy Applications --require-approval=never
+          cdk deploy Applications --exclusively --require-approval=never
           cdk deploy FisServerless --require-approval=never
 
       - name: Deploy Observability Stack

--- a/.github/workflows/deploy_main.yml
+++ b/.github/workflows/deploy_main.yml
@@ -90,42 +90,37 @@ jobs:
           aws cloudformation list-stacks --query 'StackSummaries[?(StackName==`CDKToolkit` && StackStatus==`CREATE_COMPLETE`)].StackId' --output text
         if: steps.cache.outputs.cache-hit != 'true'
 
+      # The workshop is single-region since PR #193; the former *Secondary,
+      # Network*, and S3Replica stacks no longer exist in the CDK app.
       - name: Deploy Pet Stack Services
         working-directory: ./PetAdoptions/cdk/pet_stack
         run: |
           npm install
           npm run build
-          cdk deploy Services --context admin_role=$EE_TEAM_ROLE_ARN --context is_event_engine="false" --require-approval=never 
-          cdk deploy ServicesSecondary --context admin_role=$EE_TEAM_ROLE_ARN --context is_event_engine="false" --require-approval=never 
-
-      - name: Deploy Network Stacks
-        working-directory: ./PetAdoptions/cdk/pet_stack
-        run: |
-          cdk deploy NetworkRegionPeering --require-approval=never
-          cdk deploy NetworkRoutesMain --require-approval=never
-          cdk deploy NetworkRoutesSecondary --require-approval=never
+          cdk deploy Services --context admin_role=$EE_TEAM_ROLE_ARN --context is_event_engine="false" --require-approval=never
 
       - name: Deploy Application Stacks
         working-directory: ./PetAdoptions/cdk/pet_stack
         run: |
-          cdk deploy S3Replica --require-approval=never
           cdk deploy Applications --require-approval=never
-          cdk deploy ApplicationsSecondary --require-approval=never
           cdk deploy FisServerless --require-approval=never
 
-      - name: Deploy Observability Stacks
+      - name: Deploy Observability Stack
         working-directory: ./PetAdoptions/cdk/pet_stack
         run: |
           cdk deploy Observability --require-approval=never
-          cdk deploy ObservabilitySecondary --require-approval=never
-          cdk deploy ObservabilityDashboard --require-approval=never
 
-      - name: Deploy User Simulation Stacks
+      # Same order as buildspec.yml: dashboard deploys after user simulation.
+      - name: Deploy User Simulation Stack
         working-directory: ./PetAdoptions/cdk/pet_stack
         run: |
           cdk deploy UserSimulationStack --require-approval=never
           sh ../../../az-experiment/scripts/removeusersimtags.sh
-          cdk deploy UserSimulationStackSecondary --require-approval=never
+
+      - name: Deploy Observability Dashboard
+        working-directory: ./PetAdoptions/cdk/pet_stack
+        run: |
+          cdk deploy ObservabilityDashboard --require-approval=never
 
       - name: Deploy Intro Experiment
         working-directory: ./intro-experiment/cdk

--- a/.github/workflows/deploy_main.yml
+++ b/.github/workflows/deploy_main.yml
@@ -44,34 +44,6 @@ jobs:
         run: |
           aws sts get-caller-identity
 
-      - name: Delete UserSimulationStack Log Groups
-        run: |
-          echo "Searching for log groups containing 'UserSimulationStack'"
-          # Get the log groups containing UserSimulationStack
-          LOG_GROUPS=$(aws logs describe-log-groups \
-            --query "logGroups[?contains(logGroupName, 'UserSimulationStack')].logGroupName" \
-            --output text)
-
-          # Check if any log groups were found
-          if [ -z "$LOG_GROUPS" ] || [ "$LOG_GROUPS" = "None" ]; then
-              echo "No log groups found containing 'UserSimulationStack'. Skipping deletion."
-              exit 0
-          fi
-
-          # Process each log group
-          echo "$LOG_GROUPS" | tr '\t' '\n' | while read -r log_group; do
-              if [ ! -z "$log_group" ]; then
-                  echo "Deleting log group: $log_group"
-                  if aws logs delete-log-group --log-group-name "$log_group"; then
-                      echo "Successfully deleted: $log_group"
-                  else
-                      echo "Failed to delete: $log_group"
-                  fi
-              fi
-          done
-          echo "Finished processing log groups" 
-        shell: bash 
-
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:

--- a/PetAdoptions/cdk/pet_stack/app/pet_stack.ts
+++ b/PetAdoptions/cdk/pet_stack/app/pet_stack.ts
@@ -28,6 +28,11 @@ const applications = new Applications(app, "Applications", {
     region: process.env.CDK_DEFAULT_REGION
   },
 });
+// Applications imports the PetSite cluster by name (fromClusterAttributes),
+// which CloudFormation can't see as a dependency. Without this hint,
+// `cdk destroy --all` may delete Services (and the cluster) first, leaving
+// Applications' kubectl resources unable to delete (update-kubeconfig 255).
+applications.addDependency(stack_primary);
 
 const fis_serverless = new FisServerless(app, "FisServerless", {
   env: {

--- a/PetAdoptions/cdk/pet_stack/lib/common/services-shared.ts
+++ b/PetAdoptions/cdk/pet_stack/lib/common/services-shared.ts
@@ -11,6 +11,7 @@ import * as ddb from 'aws-cdk-lib/aws-dynamodb'
 import { RemovalPolicy, Tags } from 'aws-cdk-lib';
 import * as s3 from 'aws-cdk-lib/aws-s3'
 import * as iam from 'aws-cdk-lib/aws-iam';
+import * as cr from 'aws-cdk-lib/custom-resources';
 
 
 //Create ListAdoptionsService
@@ -168,6 +169,26 @@ export function createRDSCluster(props: CreateRDSClusterProps): RDSClusterResult
     rdssecuritygroup.addIngressRule(ec2.Peer.ipv4(props.vpcCidr), ec2.Port.tcp(5432), 'Allow Aurora PG access from within the VPC CIDR range');
 
     const rdsUsername = props.rdsUsername || "petadmin";
+
+    // Freshly vended workshop accounts have no AWSServiceRoleForRDS; RDS's
+    // implicit creation of it can race and fail the whole Services deploy.
+    // Pre-create it idempotently (InvalidInput = role already exists).
+    const rdsServiceLinkedRole = new cr.AwsCustomResource(props.scope, 'RdsServiceLinkedRole', {
+        onCreate: {
+            service: 'IAM',
+            action: 'createServiceLinkedRole',
+            parameters: { AWSServiceName: 'rds.amazonaws.com' },
+            physicalResourceId: cr.PhysicalResourceId.of('rds-service-linked-role'),
+            ignoreErrorCodesMatching: 'InvalidInput',
+        },
+        policy: cr.AwsCustomResourcePolicy.fromStatements([
+            new iam.PolicyStatement({
+                actions: ['iam:CreateServiceLinkedRole'],
+                resources: ['arn:aws:iam::*:role/aws-service-role/rds.amazonaws.com/*'],
+            }),
+        ]),
+    });
+
     const auroraCluster = new rds.DatabaseCluster(props.scope, 'Database', {
         credentials: { username: rdsUsername },
         engine: rds.DatabaseClusterEngine.auroraPostgres({ version: rds.AuroraPostgresEngineVersion.VER_15_10 }),
@@ -182,8 +203,13 @@ export function createRDSCluster(props: CreateRDSClusterProps): RDSClusterResult
         parameterGroup: rds.ParameterGroup.fromParameterGroupName(props.scope, 'ParameterGroup', 'default.aurora-postgresql15'),
         vpc: props.vpc,
         securityGroups: [rdssecuritygroup],
-        defaultDatabaseName: 'adoptions'
+        defaultDatabaseName: 'adoptions',
+        // Workshop database is disposable; without DESTROY the default SNAPSHOT
+        // policy creates a manual snapshot on every CI teardown until the
+        // 100-snapshot account quota blocks stack deletion entirely.
+        removalPolicy: RemovalPolicy.DESTROY
     });
+    auroraCluster.node.addDependency(rdsServiceLinkedRole);
 
     if (auroraCluster.secret === undefined) {
         throw new Error("RDS Doesn't have a secret");

--- a/PetAdoptions/cdk/pet_stack/lib/services.ts
+++ b/PetAdoptions/cdk/pet_stack/lib/services.ts
@@ -359,7 +359,10 @@ export class Services extends Stack {
             assumedBy: new iam.AccountRootPrincipal()
         });
 
-        const secretsKey = new kms.Key(this, 'SecretsKey');
+        // Without DESTROY the key is orphaned (and billed) on every CI teardown.
+        const secretsKey = new kms.Key(this, 'SecretsKey', {
+            removalPolicy: RemovalPolicy.DESTROY
+        });
 
         const cluster = new eks.Cluster(this, 'petsite', {
             clusterName: 'PetSite',

--- a/PetAdoptions/cdk/pet_stack/lib/user_simulation-stack.ts
+++ b/PetAdoptions/cdk/pet_stack/lib/user_simulation-stack.ts
@@ -1,8 +1,9 @@
-import { Stack, StackProps } from 'aws-cdk-lib';
+import { RemovalPolicy, Stack, StackProps } from 'aws-cdk-lib';
 import * as ecs from 'aws-cdk-lib/aws-ecs';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as ecr from 'aws-cdk-lib/aws-ecr';
 import * as iam from 'aws-cdk-lib/aws-iam';
+import * as logs from 'aws-cdk-lib/aws-logs';
 import * as cdk from 'aws-cdk-lib/core';
 import { Construct } from 'constructs'
 import path = require('path');
@@ -46,7 +47,11 @@ export class UserSimulationStack extends cdk.Stack {
       // Add a container to the task definition using your Docker image
       const catAdoptContainer = catAdoptTaskDefinition.addContainer('catAdoptContainer', {
         image: ecs.ContainerImage.fromAsset('./resources/user_simulation/catadopt'),
-        logging: new ecs.AwsLogDriver({ streamPrefix: 'catadopt' }),
+        logging: new ecs.AwsLogDriver({
+          streamPrefix: 'catadopt',
+          // Explicit log group so it is destroyed with the stack instead of retained.
+          logGroup: new logs.LogGroup(this, 'catAdoptLogGroup', { removalPolicy: RemovalPolicy.DESTROY }),
+        }),
       });
 
       // Configure container settings, environment variables, etc.
@@ -83,7 +88,10 @@ export class UserSimulationStack extends cdk.Stack {
       // Add a container to the task definition using your Docker image
       const dogAdoptContainer = dogAdoptTaskDefinition.addContainer('dogAdoptContainer', {
         image: ecs.ContainerImage.fromAsset('./resources/user_simulation/dogadopt'),
-        logging: new ecs.AwsLogDriver({ streamPrefix: 'dogadopt' }),
+        logging: new ecs.AwsLogDriver({
+          streamPrefix: 'dogadopt',
+          logGroup: new logs.LogGroup(this, 'dogAdoptLogGroup', { removalPolicy: RemovalPolicy.DESTROY }),
+        }),
       });
 
       // Configure container settings, environment variables, etc.
@@ -116,7 +124,10 @@ export class UserSimulationStack extends cdk.Stack {
     // Add a container to the task definition using your Docker image
     const getAllPetsContainer = getAllPetsTaskDefinition.addContainer('getAllPetsContainer', {
       image: ecs.ContainerImage.fromAsset('./resources/user_simulation/getallpets'),
-      logging: new ecs.AwsLogDriver({ streamPrefix: 'getallpets' }),
+      logging: new ecs.AwsLogDriver({
+        streamPrefix: 'getallpets',
+        logGroup: new logs.LogGroup(this, 'getAllPetsLogGroup', { removalPolicy: RemovalPolicy.DESTROY }),
+      }),
     });
 
     // Configure container settings, environment variables, etc.
@@ -149,7 +160,10 @@ export class UserSimulationStack extends cdk.Stack {
     // Add a container to the task definition using your Docker image
     const searchListContainer = searchListTaskDefinition.addContainer('searchListContainer', {
       image: ecs.ContainerImage.fromAsset('./resources/user_simulation/searchlist'),
-      logging: new ecs.AwsLogDriver({ streamPrefix: 'searchlist' }),
+      logging: new ecs.AwsLogDriver({
+        streamPrefix: 'searchlist',
+        logGroup: new logs.LogGroup(this, 'searchListLogGroup', { removalPolicy: RemovalPolicy.DESTROY }),
+      }),
     });
 
     // Configure container settings, environment variables, etc.
@@ -252,7 +266,10 @@ CMD ["./monitor"]`;
     // Add a container to the task definition using your Docker image
     const azMonitorContainer = azMonitorTaskDefinition.addContainer('azMonitorContainer', {
       image: ecs.ContainerImage.fromAsset(azMonitorDockerBuildDir),
-      logging: new ecs.AwsLogDriver({ streamPrefix: 'azmonitor' }),
+      logging: new ecs.AwsLogDriver({
+        streamPrefix: 'azmonitor',
+        logGroup: new logs.LogGroup(this, 'azMonitorLogGroup', { removalPolicy: RemovalPolicy.DESTROY }),
+      }),
     });
 
 

--- a/bring-your-own-account/cdk/lib/fis-workshop-stack.ts
+++ b/bring-your-own-account/cdk/lib/fis-workshop-stack.ts
@@ -149,7 +149,7 @@ export class FisWorkshopStack extends cdk.Stack {
                             'mkdir -p ./out',
                             'cdk synth Services --context admin_role="${EE_TEAM_ROLE_ARN}" --context is_event_engine="${IS_EVENT_ENGINE}"',
                             'cdk deploy Services --context admin_role="${EE_TEAM_ROLE_ARN}" --context is_event_engine="${IS_EVENT_ENGINE}" --require-approval=never --verbose -O ./out/out.json',
-                            'cdk deploy Applications --require-approval=never --verbose -O ./out/out.json',
+                            'cdk deploy Applications --exclusively --require-approval=never --verbose -O ./out/out.json',
                             'cdk deploy FisServerless --require-approval never --verbose -O ./out/out.json',
                             'cdk deploy Observability --require-approval never --verbose -O ./out/out.json',
                             'cdk deploy UserSimulationStack --require-approval never --verbose -O ./out/out.json',

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -14,7 +14,7 @@ phases:
       - npm install
       - npm run build
       - cdk deploy Services --context admin_role=${EE_TEAM_ROLE_ARN} --context is_event_engine="true" --require-approval=never --verbose -O ./out/out.json
-      - cdk deploy Applications --require-approval=never --verbose -O ./out/out.json
+      - cdk deploy Applications --exclusively --require-approval=never --verbose -O ./out/out.json
       - cdk deploy FisServerless --require-approval never --verbose -O ./out/out.json
       - cdk deploy Observability --require-approval never --verbose -O ./out/out.json
       - cdk deploy UserSimulationStack --require-approval never --verbose -O ./out/out.json


### PR DESCRIPTION

- Pre-create AWSServiceRoleForRDS via AwsCustomResource before the Aurora cluster (idempotent: InvalidInput ignored when the role exists). RDS's implicit SLR creation raced and failed a Workshop Studio account deploy with "Unable to create the resource. Verify that you have permission to create service linked role."
- Aurora cluster: removalPolicy DESTROY 
- EKS SecretsKey KMS key: DESTROY
- UserSimulationStack containers: explicit log groups with DESTROY

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
